### PR TITLE
fix: 폴더 및 히스토리 이름 제약 예외 처리

### DIFF
--- a/src/main/java/com/phraiz/back/common/exception/GlobalErrorCode.java
+++ b/src/main/java/com/phraiz/back/common/exception/GlobalErrorCode.java
@@ -32,7 +32,18 @@ public enum GlobalErrorCode implements ErrorCode {
     AUTH_USER_NOT_FOUND(401, "AUTH006", "인증 대상 사용자를 찾을 수 없습니다.", "SECURITY"),
     AUTH_REDIS_ERROR(503, "AUTH007", "세션 검증 중 캐시 서버 오류가 발생했습니다.", "SECURITY"),
     AUTH_SECURITY_CONTEXT_ERROR(500, "AUTH008", "보안 컨텍스트 설정 중 오류가 발생했습니다.", "SECURITY"),
-    AUTH_INTERNAL(500, "AUTH999", "인증 처리 중 내부 오류가 발생했습니다.", "SECURITY");
+    AUTH_INTERNAL(500, "AUTH999", "인증 처리 중 내부 오류가 발생했습니다.", "SECURITY"),
+
+    //폴더 및 히스토리
+    FOLDER_NAME_EXISTS(401, "CLT001", "폴더 이름은 중복될 수 없습니다.", "FOLDER"),
+    FOLDER_NOT_EXISTS(401, "CLT002", "존재하지 않는 폴더입니다.", "FOLDER"),
+
+    HISTORY_NAME_EXISTS(401, "CLT003", "하나의 폴더에서 히스토리 이름은 중복될 수 없습니다.", "HISTORY"),
+    DUPLICATED_HISTORY_EXISTS(401, "CLD004", "해당 폴더에 히스토리 이름이 겹칩니다.", "HISTORY"),
+    HISTORY_NOT_EXISTS(401, "CLT004", "존재하지 않는 히스토리입니다.", "HISTORY"),
+
+
+            ;
 
 
     private final int status;

--- a/src/main/java/com/phraiz/back/common/service/AbstractFolderService.java
+++ b/src/main/java/com/phraiz/back/common/service/AbstractFolderService.java
@@ -2,9 +2,12 @@ package com.phraiz.back.common.service;
 
 import com.phraiz.back.common.domain.BaseFolder;
 import com.phraiz.back.common.dto.response.FoldersResponseDTO;
+import com.phraiz.back.common.exception.GlobalErrorCode;
+import com.phraiz.back.common.exception.custom.BusinessLogicException;
 import com.phraiz.back.common.repository.BaseFolderRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -33,21 +36,25 @@ public abstract class AbstractFolderService<E extends BaseFolder> {
         validateCreateFolder(memberId);
 
         if (repo.existsByMemberIdAndName(memberId, name)) {
-            throw new IllegalArgumentException("이미 같은 이름의 폴더가 존재합니다.");
-            // Todo. 예외 처리
+            throw new BusinessLogicException(GlobalErrorCode.FOLDER_NAME_EXISTS);
         }
         E entity = newFolderEntity(memberId, name);   // ← 도메인별 팩토리 메서드
         repo.save(entity);
     }
     public void renameFolder(String memberId, Long id, String name) {
         E folder = repo.findByIdAndMemberId(id, memberId)
-                .orElseThrow(() -> new EntityNotFoundException("폴더를 찾을 수 없습니다."));
-        // Todo. 예외처리
-        folder.setName(name);
+                .orElseThrow(() -> new BusinessLogicException(GlobalErrorCode.FOLDER_NOT_EXISTS));
+        // 같은 이름의 폴더 생성 불가능하게.
+        try {
+            folder.setName(name);
+            repo.save(folder); // 변경 감지로도 가능하지만, save 호출해서 예외 포착 확실히
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessLogicException(GlobalErrorCode.FOLDER_NAME_EXISTS);
+        }
     }
     public void deleteFolder(String memberId, Long id) {
         E folder = repo.findByIdAndMemberId(id, memberId)
-                .orElseThrow(() -> new EntityNotFoundException("폴더를 찾을 수 없습니다."));
+                .orElseThrow(() -> new BusinessLogicException(GlobalErrorCode.FOLDER_NOT_EXISTS));
         repo.delete(folder);
     }
 


### PR DESCRIPTION
 - AbstractFolderService - createFolder, renameFolder에서 예외 추가
 - AbstractHistoryService - createHistory, updateHistory에서 예외 추가
 - GlobalErrorCode에 폴더/히스토리 관련 에러코드 추가